### PR TITLE
docs: :memo: add type-along on GitHub notifications

### DIFF
--- a/sessions/using-issues.qmd
+++ b/sessions/using-issues.qmd
@@ -49,6 +49,31 @@ You now have an issue to remind yourself of recipes you want to add!
 
 {{< text_snippet sticky_up >}}
 
+## GitHub notifications
+
+Now that you've been tagged in your neighbour's issue, you will have
+received a notification on GitHub (and probably also an email).
+
+To see the notification, we'll click on the notification button in the
+top right corner of the GitHub page. It looks like a tray. This will
+show a list of your notifications, including the one from your
+neighbour's issue.
+
+Let's take a moment to look at the information in this notification. We
+can see the title of the issue, who created it, and the repository it's
+in. We can also see that we've been mentioned in this issue.
+
+If we click on the notification, it will take us to the issue page. Here
+we can see the issue title, description, and comments.
+
+Since you've been tagged in your neighbour's issue, finding the issue is
+easy. You can go to the notifications by clicking the button in the top
+right corner on GitHub and click on the issue to see the details.
+
+However, if you hadn't been tagged, you couldn't find the issue this
+way. So, let's practice finding the issue in your neighbour's
+repository.
+
 ## :woman_technologist: Exercise: Comment on your neighbour's issue with a recipe suggestion
 
 **Time: \~10 minutes**

--- a/sessions/using-issues.qmd
+++ b/sessions/using-issues.qmd
@@ -51,6 +51,8 @@ You now have an issue to remind yourself of recipes you want to add!
 
 ## GitHub notifications
 
+TODO: Add an instructor note here to talk about how to walk through notification tab.
+
 Now that you've been tagged in your neighbour's issue, you will have
 received a notification on GitHub (and probably also an email).
 

--- a/sessions/using-issues.qmd
+++ b/sessions/using-issues.qmd
@@ -72,7 +72,7 @@ Since you've been tagged in your neighbour's issue, finding the issue is
 easy. You can go to the notifications by clicking the button in the top
 right corner on GitHub and click on the issue to see the details.
 
-However, if you hadn't been tagged, you couldn't find the issue this
+However, if you hadn't been tagged, you can't find the issue this
 way. So, let's practice finding the issue in your neighbour's
 repository.
 

--- a/sessions/using-issues.qmd
+++ b/sessions/using-issues.qmd
@@ -54,10 +54,10 @@ You now have an issue to remind yourself of recipes you want to add!
 Now that you've been tagged in your neighbour's issue, you will have
 received a notification on GitHub (and probably also an email).
 
-To see the notification, we'll click on the notification button in the
-top right corner of the GitHub page. It looks like a tray. This will
-show a list of your notifications, including the one from your
-neighbour's issue.
+To see the notification, we'll click on the notification button with the
+inbox icon in the top right corner of the GitHub page. This will show a
+list of your notifications, including the one from your neighbour's
+issue.
 
 Let's take a moment to look at the information in this notification. We
 can see the title of the issue, who created it, and the repository it's


### PR DESCRIPTION
## Description

Since they have tagged their neighbour in the previous exercise, I thought it would be a good idea to add a short section on how to navigate the notifications on GitHub.

Related to #62 
Actually also related to #84 

<!-- Please delete as appropriate: -->
This PR needs an in-depth review.

## Checklist

- [X] Formatted Markdown
