### PR TITLE
docs: :memo: add summary section to issues session

### DIFF
--- a/sessions/using-issues.qmd
+++ b/sessions/using-issues.qmd
@@ -286,7 +286,7 @@ have:
 -   Created our first issues: One to keep track of a future task (adding
     the `sweets/` folder) and one to start brainstorming ideas on which
     recipes to add in the future.
--   Explored GitHub notifications
+-   Explored GitHub notifications.
 -   Navigated Github to find other people's repositories and issues.
 -   Started collaborating a bit by commenting on someone else's issue to
     suggest a recipe.

--- a/sessions/using-issues.qmd
+++ b/sessions/using-issues.qmd
@@ -135,4 +135,13 @@ advantages (and barriers) there are to using issues in your own work.
 
 ## Summary
 
--   TODO: List of summary items
+In this session, we have learned about GitHub Issues. Specifically, we
+have:
+
+-   Created our first issues: One to keep track of a future task (adding
+    the `sweets/` folder) and one to start brainstorming ideas on which
+    recipes to add in the future.
+-   Explored GitHub notifications
+-   Navigated Github to find other people's repositories and issues.
+-   Started collaborating a bit by commenting on someone else's issue to
+    suggest a recipe.


### PR DESCRIPTION
## Description

This PR adds a summary section to the issues session. This might need to change based on the other PRs related to this session. 

Related to #62 
Closes #62 (bc it’s the last part of this session).

<!-- Please delete as appropriate: -->
This PR needs an in-depth review.

## Checklist

- [X] Formatted Markdown
