### PR TITLE
refactor: ♻️ minor rephrasings and styling on landing page and in preamble

### DIFF
--- a/includes/objectives/_basics.qmd
+++ b/includes/objectives/_basics.qmd
@@ -1,6 +1,6 @@
 -   List and describe Git's core functionality and purpose, and how
     GitHub expands on that.
--   Explain the difference between GitHub and Git.
+-   Explain the difference between Git and GitHub.
 -   Explain how GitHub differs from services like OneDrive or Dropbox,
     and what GitHub's advantage is over them.
 -   Navigate to commonly used sections on GitHub, like the list

--- a/index.qmd
+++ b/index.qmd
@@ -31,7 +31,7 @@ more visibility! :star2:
 This website and its content are targeted to three groups:
 
 1.  For the **learners** to use during the workshop, both to follow along
-    in case they get lost and also to use as a reference after the
+    and also to use as a reference after the
     workshop ends. A more detailed description of who the learner is can
     be found in @sec-is-it-for-you.
 2.  For the **instructors** to use as a guide for when they do the

--- a/index.qmd
+++ b/index.qmd
@@ -1,4 +1,4 @@
-# Welcome!
+# Welcome! {.unnumbered}
 
 This 3-hour workshop is a gentle introduction to using [GitHub](https://github.com/) for
 managing and working with files. It is designed for doing participatory

--- a/preamble/pre-workshop.qmd
+++ b/preamble/pre-workshop.qmd
@@ -4,7 +4,7 @@ In order to participate in this workshop, you must complete everything
 in this section and finish with **completing the
 [survey](@sec-pre-workshop-survey)** at the end. These tasks are
 designed to make it easier for everyone to start the workshop with
-everything set up.
+everything set up and a shared foundation to build on.
 
 Depending on your skills and knowledge, these tasks could take between
 **1-2 hrs to finish**, so we suggest planning some time to complete

--- a/preamble/schedule.qmd
+++ b/preamble/schedule.qmd
@@ -2,8 +2,8 @@
 
 This 3-hour workshop is structured as a participatory live-coding
 session interspersed with a few hands-on exercises, reading tasks, and
-discussion activities. The *general* schedule is outlined in the below
-table and is meant as an approximate guide *only*. The actual time spent
+discussion activities. The *general* schedule is outlined in the table
+below and is meant as an approximate guide *only*. The actual time spent
 on each session may vary a bit.
 
 | Minutes | Session topic |

--- a/preamble/syllabus.qmd
+++ b/preamble/syllabus.qmd
@@ -28,9 +28,7 @@ will enable you to:
 Tangibly, during the workshop we will:
 
 -   Create your own project on GitHub (known as a *repository*)
-
 -   Create and edit text files and folders on GitHub.
-
 -   Create GitHub Issues and comment on them.
 
 ## Is this for you? {#sec-is-it-for-you}
@@ -40,12 +38,9 @@ we make a few possible assumptions about *who you are* as a participant
 in the workshop, such as one or more of the following:
 
 -   You want a gentle introduction to what GitHub is and how to use it.
-
 -   You mostly work alone or maybe irregularly with someone else on your
     project.
-
 -   You write text in documents as a main activity of your work.
-
 -   You are able to and are comfortable enough with only working on
     files through a web browser interface (like GitHub's interface).
 
@@ -60,11 +55,8 @@ if this workshop is for you.
 
 -   We will only interact with GitHub from the website and from a web
     browser.
-
 -   We will only write *text*, there will be no code or programming.
-
 -   While we will write in a `.md` Markdown file, we will not write or
     cover Markdown syntax.
-
 -   We will not go over too many details of Git (a software that GitHub
     relies on).

--- a/preamble/syllabus.qmd
+++ b/preamble/syllabus.qmd
@@ -51,7 +51,7 @@ in the workshop, such as one or more of the following:
 
 While we have these assumptions to help focus the content of the
 workshop, if you have an interest in the workshop but don't fit any of
-the assumptions, *you are still welcome to attend*! We welcome everyone 
+the assumptions, *you are still welcome to attend*! We welcome everyone
 until capacity has been reached.
 
 In addition to the assumptions, we also have a fairly focused scope for

--- a/preamble/syllabus.qmd
+++ b/preamble/syllabus.qmd
@@ -18,11 +18,19 @@ The aim of this workshop is to enable you to:
 -   Explain in simple terms what GitHub does and navigate GitHub to work
     with files and GitHub Issues.
 
-Broken down into specific objectives within a few sessions, the workshop
+Broken down into specific objectives within each session, the workshop
 will enable you to:
 
+[The basics of GitHub and Git](/sessions/basics.qmd)
+
 {{< include /includes/objectives/_basics.qmd >}}
+
+[Working with files on GitHub](/sessions/working-with-files.qmd)
+
 {{< include /includes/objectives/_working-with-files.qmd >}}
+
+[Making and using GitHub Issues](/sessions/using-issues.qmd)
+
 {{< include /includes/objectives/_using-issues.qmd >}}
 
 Tangibly, during the workshop we will:

--- a/preamble/syllabus.qmd
+++ b/preamble/syllabus.qmd
@@ -27,7 +27,7 @@ will enable you to:
 
 Tangibly, during the workshop we will:
 
--   Create your own GitHub project (known as a *repository*)
+-   Create your own project on GitHub (known as a *repository*)
 
 -   Create and edit text files on GitHub.
 

--- a/preamble/syllabus.qmd
+++ b/preamble/syllabus.qmd
@@ -29,7 +29,7 @@ Tangibly, during the workshop we will:
 
 -   Create your own project on GitHub (known as a *repository*)
 
--   Create and edit text files on GitHub.
+-   Create and edit text files and folders on GitHub.
 
 -   Create GitHub Issues and comment on them.
 
@@ -51,8 +51,8 @@ in the workshop, such as one or more of the following:
 
 While we have these assumptions to help focus the content of the
 workshop, if you have an interest in the workshop but don't fit any of
-the assumptions, *you are still welcome to attend*! We welcome everyone,
-that is until capacity has been reached.
+the assumptions, *you are still welcome to attend*! We welcome everyone 
+until capacity has been reached.
 
 In addition to the assumptions, we also have a fairly focused scope for
 teaching and expectations for learning. So this may also help you decide
@@ -61,8 +61,7 @@ if this workshop is for you.
 -   We will only interact with GitHub from the website and from a web
     browser.
 
--   We will only write *text*, there will be no code or programming
-    used.
+-   We will only write *text*, there will be no code or programming.
 
 -   While we will write in a `.md` Markdown file, we will not write or
     cover Markdown syntax.

--- a/preamble/syllabus.qmd
+++ b/preamble/syllabus.qmd
@@ -5,11 +5,11 @@
 This workshop lasts 3 hours and is split into the following sessions,
 which will be covered in order:
 
--   [Introduction to the workshop](/sessions/introduction.qmd)
--   [The basics of GitHub and Git](/sessions/basics.qmd)
--   [Working with files on GitHub](/sessions/working-with-files.qmd)
--   [Making and using GitHub Issues](/sessions/using-issues.qmd)
--   [Concluding remarks](/sessions/conclusion.qmd)
+-   Introduction to the workshop in [session @sec-introduction]
+-   The basics of GitHub and Git in [session @sec-basics]
+-   Working with files on GitHub in [session @sec-working-with-files]
+-   Making and using GitHub Issues in [session @sec-using-issues]
+-   Concluding remarks in [session @sec-conclusion]
 
 ## Learning outcome and objectives
 
@@ -18,18 +18,18 @@ The aim of this workshop is to enable you to:
 -   Explain in simple terms what GitHub does and navigate GitHub to work
     with files and GitHub Issues.
 
-Broken down into specific objectives within each session, the workshop
-will enable you to:
+Broken down into specific objectives, the workshop
+will enable you to do the following, by session:
 
-[The basics of GitHub and Git](/sessions/basics.qmd)
+**The basics of GitHub and Git** ([session @sec-basics])
 
 {{< include /includes/objectives/_basics.qmd >}}
 
-[Working with files on GitHub](/sessions/working-with-files.qmd)
+**Working with files on GitHub** ([session @sec-working-with-files])
 
 {{< include /includes/objectives/_working-with-files.qmd >}}
 
-[Making and using GitHub Issues](/sessions/using-issues.qmd)
+**Making and using GitHub Issues** ([session @sec-using-issues])
 
 {{< include /includes/objectives/_using-issues.qmd >}}
 


### PR DESCRIPTION
## Description

This is mostly minor rephrasings ✏️  

The last two commits are about styling of the lists. I removed empty lines between the bullet points to they are then rendered closer together. However, for the includes that are right after each other, I *think* the blank line at the end of each of them makes Quarto render them with blank lines between them. As a potential fix, I divided the objectives into the learning outcomes of each session. 

I’m not sure I particularly like this fix, but I couldn’t find a way to render them as one collected list without the blank lines in between. Thoughts? 😬 

Annoying blank lines look like this: 

<img src="https://github.com/user-attachments/assets/48c01543-076c-4d9f-a45f-d4722dda5dad" width="500">




What I want is this (ideally without each includes in its own section - but maybe it isn’t too bad?): 

<img src="https://github.com/user-attachments/assets/40a01740-bd5e-4a10-8fbc-cb3cc7d5e209" width="500">

<!-- Please delete as appropriate: -->
This PR needs an in-depth review.

## Checklist

- [X] Formatted Markdown
- [X] Ran `just run-all`
