### PR TITLE
fix: remove duplicate "license"

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -5,5 +5,4 @@ Copyright (c) 2025 Luke W. Johnston and Signe Kirk Brødbæk
 <a rel="license" href="https://creativecommons.org/licenses/by/4.0/"><img src="https://i.creativecommons.org/l/by/4.0/88x31.png" alt="Creative Commons License" style="border-width:0"/></a>
 
 The workshop material is licensed under the [Creative Commons Attribution
-4.0 International License](https://creativecommons.org/licenses/by/4.0/)
-License.
+4.0 International License](https://creativecommons.org/licenses/by/4.0/).


### PR DESCRIPTION
## Description 

So it doesn’t say “License License”.

<!-- Please delete as appropriate: -->
This PR needs a quick review.