### PR TITLE
refactor(sessions): :recycle: simplify callout note on vc and git reading repetition

### DIFF
--- a/sessions/basics.qmd
+++ b/sessions/basics.qmd
@@ -39,15 +39,15 @@ text, such as:
 **Time: \~5 minutes.**
 
 ::: callout-note
-This is the same text you read for the pre-workshop tasks. Why are we
-getting you to do a discussion activity, then getting you to again
-re-read the text? We're doing this because we know that learning and
-understanding Git can be *very hard*, so we're giving you repeated
-exposures to it, by both getting you to retrieve, discuss, and reread
-it. Git requires you work with files in a fundamentally different way
-than people usually work, so we want to give you multiple of exposures
-to Git does before moving into the practical parts of this workshop. By
-including this repetition we aim to reinforce these new concepts.
+The text below is the same text you read for the pre-workshop tasks. 
+
+So, **why are we asking you to discuss it and then read it again?**
+
+Because Git is *hard* to learn. It changes how you think about working
+with files, which often takes time to adjust to. By revisiting the material
+through reading, discussion, and rereading we want to help you build
+familiarity with these concepts before moving on to the hands-on parts
+of the workshop.
 :::
 
 {{< include /includes/_git-basics.qmd >}}
@@ -277,14 +277,14 @@ commit, they look like:
 
 1.  Create repo with README: 'README.md'
 
-    ```
+    ```         
     recipes/
     └── README.md
     ```
 
 2.  Add a new recipe file: 'toup.md'
 
-    ```
+    ```         
     recipes/
     ├── README.md
     └── toup.md <- new file
@@ -292,7 +292,7 @@ commit, they look like:
 
 3.  Fix a typo: 'soup.md'
 
-    ```
+    ```         
     recipes/
     ├── README.md
     └── soup.md <- typo fix
@@ -300,7 +300,7 @@ commit, they look like:
 
 4.  Move file to new folder: 'soups/tomato.md'
 
-    ```
+    ```         
     recipes/
     ├── README.md
     └── soup/ <- new folder
@@ -309,7 +309,7 @@ commit, they look like:
 
 5.  Add a new recipe file: 'baked-goods/cookies.md'
 
-    ```
+    ```         
     recipes/
     ├── README.md
     ├── soup/

--- a/sessions/basics.qmd
+++ b/sessions/basics.qmd
@@ -39,7 +39,7 @@ text, such as:
 **Time: \~5 minutes.**
 
 ::: callout-note
-The text below is the same text you read for the pre-workshop tasks. 
+The text below is the same text you read for the pre-workshop tasks.
 
 So, **why are we asking you to discuss it and then read it again?**
 
@@ -277,14 +277,14 @@ commit, they look like:
 
 1.  Create repo with README: 'README.md'
 
-    ```         
+    ```
     recipes/
     └── README.md
     ```
 
 2.  Add a new recipe file: 'toup.md'
 
-    ```         
+    ```
     recipes/
     ├── README.md
     └── toup.md <- new file
@@ -292,7 +292,7 @@ commit, they look like:
 
 3.  Fix a typo: 'soup.md'
 
-    ```         
+    ```
     recipes/
     ├── README.md
     └── soup.md <- typo fix
@@ -300,7 +300,7 @@ commit, they look like:
 
 4.  Move file to new folder: 'soups/tomato.md'
 
-    ```         
+    ```
     recipes/
     ├── README.md
     └── soup/ <- new folder
@@ -309,7 +309,7 @@ commit, they look like:
 
 5.  Add a new recipe file: 'baked-goods/cookies.md'
 
-    ```         
+    ```
     recipes/
     ├── README.md
     ├── soup/


### PR DESCRIPTION


## Description

This PR simplifies and shortens the callout note, based on feedback from @K-Beicher that the callout note was quite a "block" of text. That feedback was mostly about the layout, but I thought we could simplify the text as well, since it was a bit wordy.

<!-- Please delete as appropriate: -->
This PR needs a quick review.

## Checklist

- [X] Formatted Markdown
- [X] Ran `just run-all`
