### PR TITLE
build: :hammer: ignore more dirs when listing todos

### DIFF
--- a/justfile
+++ b/justfile
@@ -10,7 +10,11 @@ run-all: _checks _builds
 
 # List all TODOs in the repository.
 list-todos:
-  grep -R TODO . --exclude-dir=.vscode
+  grep -R TODO . \
+    --exclude-dir=.vscode \
+    --exclude-dir=_book \
+    --exclude-dir=.quarto \
+    --exclude=justfile
 
 # Install or update the pre-commit hooks
 install-precommit:


### PR DESCRIPTION
# Description

Ignore these (non-essential/only temp) dirs when listing TODOs.

No review needed.