### PR TITLE
refactor: :truck: move "why GitHub" into pre-workshop tasks

### DIFF
--- a/pre-workshop/git-and-github.qmd
+++ b/pre-workshop/git-and-github.qmd
@@ -89,9 +89,9 @@ While we've already covered some of this in the
 one of the biggest questions you may have: Why GitHub?
 
 GitHub is an extremely popular and widely used online platform for
-managing Git repositories. As you read previously, Git repositories come with a
-lot of features to work with files and track changes to them. GitHub
-does much more than that: It can be used for [project
+managing Git repositories. As you read previously, Git repositories come
+with a lot of features to work with files and track changes to them.
+GitHub does much more than that: It can be used for [project
 management](https://docs.github.com/en/issues/planning-and-tracking-with-projects/learning-about-projects/about-projects),
 running automatic [workflows](https://docs.github.com/en/actions) that
 do tasks for you, hosting [websites](https://docs.github.com/en/pages),
@@ -123,13 +123,13 @@ research community, we need to embrace and use tools that improve how we
 do our work and how we disseminate our research. And GitHub is one of
 these tools.
 
-In that context, this workshop is designed as a gentle introduction
-to using GitHub to manage your files related to your research and work.
+In that context, this workshop is designed as a gentle introduction to
+using GitHub to manage your files related to your research and work.
 Before diving into some of the more advanced uses, it's important to
-learn about and try out the basics of Git and GitHub works and how to use it effectively.
-In this workshop, our focus is to cover the most fundamental and
-important features of GitHub that will help you get started with using
-it for your own work.
+learn about and try out the basics of Git and GitHub works and how to
+use it effectively. In this workshop, our focus is to cover the most
+fundamental and important features of GitHub that will help you get
+started with using it for your own work.
 
 ## Summary of Git and GitHub
 

--- a/sessions/introduction.qmd
+++ b/sessions/introduction.qmd
@@ -54,8 +54,8 @@ to expect:
 ::: {.callout-note collapse="true"}
 ## :teacher: Teacher note
 
-Verbally and briefly go over this section, to remind the learners about the
-reason and purpose of this workshop.
+Verbally and briefly go over this section, to remind the learners about
+the reason and purpose of this workshop.
 :::
 
 As you read about in the pre-workshop tasks, GitHub is an increasingly
@@ -65,10 +65,11 @@ literature. As research becomes increasingly more dependent on
 integrated digital tools and workflows, it is essential to be familiar
 with these tools in order to be effective in present day research.
 
-This workshop aims to get you more familiar with GitHub to help you get started with using
-it in your own work. During this workshop, we'll create a Git repository on GitHub with a
-recipe book, adding, organising, and editing text files with recipes
-:cake: :pancakes: :cookie:
+This workshop aims to get you more familiar with GitHub to help you get
+started with using it in your own work. During this workshop, we'll
+create a Git repository on GitHub with a recipe book, adding,
+organising, and editing text files with recipes :cake: :pancakes:
+:cookie:
 
 This is meant to be a fun and light-hearted project that will help you
 learn the basics of Git and GitHub.


### PR DESCRIPTION
# Description

Move this text into the pre-workshop reading tasks, so that we don't need to cover it during the workshop.

Also slightly modified the intro session text, by moving some text into more appropriate sections.

Closes #164

## Checklist

- [x] Formatted Markdown
- [x] Ran `just run-all`
