### PR TITLE
refactor(sessions): :recycle: simplify workshop details in intro, highlight key items

### DIFF
--- a/sessions/introduction.qmd
+++ b/sessions/introduction.qmd
@@ -21,28 +21,28 @@ Especially highlight the use of the stickies/hats.
 
 Before we get started, let's go over some of the details of the
 workshop, which will help orient you to the workshop structure and what
-to expect. You already covered a lot of these things in detail in
+to expect. We've already covered a lot of these things in detail in
 [learning design](/overview/learning-design.qmd), so this is mostly a
 brief reminder.
 
 -   We do **"type-alongs" or "code-alongs"** where the teacher types and
-    actually shows how things are done and explains what they are doing
+    shows how to do things and explains what they are doing
     and why, while you type along.
 
--   **Reading activities** are used to give you time to think and
-    process in your own way. After the reading, the teacher repeats and
+-   **Reading tasks** are used to give you time to think and
+    process at your own pace. After the reading task, the teacher repeats and
     rephrases the key points to reinforce the concepts you just read.
 
--   **Discussion activities** are used to reinforce learning and give
+-   **Discussion activities** are used to reflect on the workshop content and give
     you a chance to talk to your peers about the concepts.
 
 -   We use **"stickies", origami hats, or other visual indicators** to
     assess how everyone is doing and for you to request help if you get
     stuck. When the "help" sticky/origami hat/indicator is up, a helper
-    will come by and help you out.
+    will come by as soon as they are available and help you out.
 
 -   The [**schedule**](/overview/schedule.qmd) **is a *guide* only**,
-    some sessions are longer, others shorter. It is not intended to be
+    some sessions might be longer, others shorter. It is not intended to be
     firm or strict.
 
 -   We depend on and want **honest, constructive, and critical


### PR DESCRIPTION
# Description

I decided against adding more things to the slides (as the issue below mentions) but instead simplified the text a bit and highlighted key text.

Closes #209

## Checklist

- [x] Formatted Markdown
- [x] Ran `just run-all`
