### PR TITLE
refactor(sessions): :recycle: shorten recipes and simplify add/edit file section

### DIFF
--- a/_variables.yml
+++ b/_variables.yml
@@ -5,7 +5,7 @@ github-commit-end: |
   Keep the "Commit directly to the main branch" option selected. Then, click
   "Commit changes" at the bottom of the pop-up.
 github-commit: |
-  {{< var github-commit-button >}} In the message section, briefly
+  {{< var github-commit-start >}} In the message section, briefly
   describe the change. {{< var github-commit-end >}}
 pencil-icon: |
   ![](/images/pencil-icon.svg){fig-alt="Pencil icon"}

--- a/_variables.yml
+++ b/_variables.yml
@@ -1,9 +1,12 @@
-github-commit: |
+github-commit-start: |
   Click the "Commit changes..." button in the top-right corner of the page
-  to open the commit message pop-up. In the message section, briefly
-  describe the change. No extended description is needed. Keep the
-  "Commit directly to the main branch" option selected. Then, click
+  to open the commit message pop-up.
+github-commit-end: |
+  Keep the "Commit directly to the main branch" option selected. Then, click
   "Commit changes" at the bottom of the pop-up.
+github-commit: |
+  {{< var github-commit-button >}} In the message section, briefly
+  describe the change. {{< var github-commit-end >}}
 pencil-icon: |
   ![](/images/pencil-icon.svg){fig-alt="Pencil icon"}
 issues-icon: |

--- a/sessions/working-with-files.qmd
+++ b/sessions/working-with-files.qmd
@@ -87,25 +87,26 @@ For the content of the file, we'll write out the following text:
 ``` markdown
 Ingredients:
 
+- Tomato
 - Onion
 - Oil
 - Water
 ```
 
 Once we have added the file name and the recipe itself, let's save the
-changes. {{< var github-commit-start >}} This will open a pop-up where
-we can add a commit message to describe the changes.
+changes. {{< var github-commit-start >}} This pop-up is where
+we will add the commit message to describe the changes we've made.
 
 You might have noticed that GitHub automatically creates a commit
-message for you. It's good practice to edit it to be descriptive, as it
+message for you. It's good practice to edit it to be more descriptive, as it
 helps you and others understand the changes that were made to the
 repository. Otherwise, you might end up with a commit history that is
 "Update file", "Update file", "Update file", etc. :grimacing: We'll use
-a descriptive message for these changes by writing "Start of soup recipe
+a descriptive message for these changes by writing "Add soup recipe
 md file".
 
-You usually don't need to add an extended description of the changes, so
-we can leave it empty. {{< var github-commit-end >}}
+We usually don't need to add an extended description of the changes, so
+we can leave it empty here. {{< var github-commit-end >}}
 
 We've now added our first recipe to the repository! :tada: Now, you'll
 practice creating files in your repository by adding another recipe.
@@ -126,7 +127,7 @@ repository: A cookie recipe! :cookie:
     file.
 3.  In the new file, write one or two lines of text of some basic
     ingredients. It doesn't even need to be a real or full recipe. The
-    point is to write something here.
+    point is to add a file to your repository, so the actual content isn't important.
 4.  Now, save the changes. {{< var github-commit-start >}} Write a
     descriptive message for these changes, like "Add cookie recipe".
     {{< var github-commit-end >}}
@@ -171,8 +172,8 @@ click on the name and rename the file to `tomato-soup.md`. Remember to
 keep the `.md` file extension.
 
 Once we have renamed the file, let's commit the changes.
-{{< var github-commit-start >}} Write the commit message for these
-changes as "Rename soup.md to tomato-soup.md".
+{{< var github-commit-start >}} Write a descriptive commit message for this
+change, e.g., "Rename soup.md to tomato-soup.md".
 {{< var github-commit-end >}}
 
 ### Move `tomato-soup.md` to a new `soups/` folder {.unnumbered}
@@ -187,22 +188,20 @@ repository, by adding `soups/` before the file name like so:
 the file name.
 
 This will create a new folder in your `recipes` repository called
-`soups/` and then move the `tomato-soup.md` file into it. Noticed that
+`soups/` and then move the `tomato-soup.md` file into it. Notice that
 once we add the slash `/` after the folder name, GitHub moves the cursor
 to the end of the file path, to the file name. This might make it seem
 like we can't go back to the folder name and correct it if we make a
-typo or want to change it.
-
-But we can still change it! If we make a mistake in the folder name, we
+typo or want to change it. But we can still change it! If we make a mistake in the folder name, we
 can fix it by using the backspace key to remove the `/`, moving the
 cursor back to the folder name. Now, we can change the folder name as we
 like :partying_face:
 
-{{< var github-commit-start >}} Write a message for these changes to be
+{{< var github-commit-start >}} Write a descriptive message for these changes like
 "Move tomato soup recipe into a new soups folder".
 {{< var github-commit-end >}}
 
-We've moved it! You can see the new folder `soups/` in the `Code` tab of
+We've now moved the file! You can see the new folder `soups/` in the `Code` tab of
 your repository and even click on it to see the `tomato-soup.md` file.
 :bowl_with_spoon: :tomato:
 

--- a/sessions/working-with-files.qmd
+++ b/sessions/working-with-files.qmd
@@ -17,7 +17,8 @@ Emphasise mainly not to use spaces in file names and *why*, not to use
 special characters and *why*, and to remember file extensions and *why*.
 
 You can show an example of why spaces aren't good by going to your
-browser and typing in a URL with a space in it, e.g., `google.com/ search`.
+browser and typing in a URL with a space in it, e.g.,
+`google.com/ search`.
 :::
 
 **Time: \~5 minutes.**
@@ -61,6 +62,13 @@ Here are some tips for good naming practices:
 
 ## Add a soup recipe
 
+::: {.callout-note collapse="true"}
+## :teacher: Teacher note
+
+Go through this slowly, stay on the same page and type out the recipe
+below, don't copy and paste.
+:::
+
 Now, it's time to create the first file on GitHub. Let's add a soup
 recipe together! :bowl_with_spoon:.
 
@@ -74,48 +82,37 @@ In the "Name your file..." field, in the top-left side of the page,
 we'll type the name of our file. Let's follow the good naming practices
 we've read about above and call it `soup.md`.
 
-For the content of the file, we'll copy and paste the following recipe:
+For the content of the file, we'll write out the following text:
 
 ``` markdown
-Ingredients for soup
+Ingredients:
 
-- 4 tbs butter
-- 0.5 large onion, cut into large wedges
-- 1 can of tomatoes
-- 1.5 cups water, vegetable or chicken stock
-- 0.5 tsp salt, or more to taste
-
-Instructions
-
-1. Melt the butter over medium heat in a large saucepan.
-2. Add onion wedges, water, tomatoes with their juices, and salt.
-3. Bring to a simmer and cook for about 40 minutes. Stir occasionally.
-4. Blend the soup, and season to taste.
+- Onion
+- Oil
+- Water
 ```
 
 Once we have added the file name and the recipe itself, let's save the
-changes. {{< var github-commit >}}
+changes. {{< var github-commit-start >}} This will open a pop-up where
+we can add a commit message to describe the changes.
 
-::: callout-tip
-A descriptive message for these changes could be "Create soup recipe md
-file"
-:::
-
-::: callout-note
 You might have noticed that GitHub automatically creates a commit
-message for you. Remember that you can edit this message to make it more
-descriptive. It's a good practice to edit it to be more descriptive, as
-it helps you and others understand the changes that were made to the
+message for you. It's good practice to edit it to be descriptive, as it
+helps you and others understand the changes that were made to the
 repository. Otherwise, you might end up with a commit history that is
-"Update file", "Update file", "Update file", etc. :grimacing:
-:::
+"Update file", "Update file", "Update file", etc. :grimacing: We'll use
+a descriptive message for these changes by writing "Start of soup recipe
+md file".
+
+You usually don't need to add an extended description of the changes, so
+we can leave it empty. {{< var github-commit-end >}}
 
 We've now added our first recipe to the repository! :tada: Now, you'll
 practice creating files in your repository by adding another recipe.
 
 ## :woman_technologist: Exercise: Add a cookie recipe to your repository
 
-**Time: \~10 minutes**
+**Time: \~3 minutes**
 
 In this exercise, you'll add the second recipe to your `recipes`
 repository: A cookie recipe! :cookie:
@@ -127,83 +124,45 @@ repository: A cookie recipe! :cookie:
     well as to add the `.md` file extension so you create a
     [Markdown](https://quarto.org/docs/authoring/markdown-basics.html)
     file.
-3.  Add a cookie recipe to the file by either finding one online or
-    using the example recipe below.
-4.  Now, save the changes. {{< var github-commit >}}
-
-::: callout-tip
-A descriptive message for these changes could be "Add cookie recipe"
-:::
-
-**Example cookie recipe:**
-
-``` markdown
-Ingredients for cookies
-
-- 240 grams flour
-- 3/4 tsp salt
-- 140 grams butter
-- 145 grams brown sugar
-- 115 grams sugar
-- 1 1/2 tsp vanilla powder
-- 1 egg
-- 1/2 tsp baking soda
-- 1 tsp baking powder
-- 150 grams chocolate (e.g., a mix of dark and milk chocolate)
-- 100 grams chopped hazelnuts (can be omitted or replaced with oats)
-
-Instructions
-
-1. Mix the sugar, brown sugar, and butter well.
-2. Add the egg and mix again.
-3. Add salt, baking powder, vanilla powder, baking soda, and flour.
-4. Add the chopped chocolate and nuts.
-5. Form clumps of dough on a baking tray with plenty of space between them.
-6. Bake at 175°C (top and bottom heat) for 16.5-17 minutes.
-7. Once baked, transfer the baking paper with the cookies onto a wire rack
-   and let them cool for 10 minutes before removing them from the paper.
-```
+3.  In the new file, write one or two lines of text of some basic
+    ingredients. It doesn't even need to be a real or full recipe. The
+    point is to write something here.
+4.  Now, save the changes. {{< var github-commit-start >}} Write a
+    descriptive message for these changes, like "Add cookie recipe".
+    {{< var github-commit-end >}}
 
 You have now added your second recipe and made another commit to your
 repository! :tada:
 
 {{< text_snippet sticky_up >}}
 
-## Edit, rename, and move the soup recipe to a new folder
+## Edit the content of a file
 
-Now, we'll take a look at how to edit, rename, and move files in
-repositories on GitHub.
+Adding a file is great, but most of the time we'll be editing existing
+files. Let's change the first line of the `soup.md` file.
 
-Let's imagine that we want to add more recipes to the repository in the
-future. To keep things organised, we want our recipes to have
-descriptive names and content. We also want to create some folders to
-group similar recipes together.
+Click the `soup.md` file in the "Code" tab of the repository to open it.
+To edit, click the pencil icon {{< var pencil-icon >}} on the top-right
+side of the page.
 
-Let's start by doing this with the soup recipe.
+Let's revise the first line of the file to be "Ingredients for tomato
+soup:". When we've made the changes, we'll commit them.
+{{< var github-commit-start >}} A descriptive commit message for these
+changes could be "Identify ingredients are for a 'tomato' soup".
+{{< var github-commit-end >}}
 
-### Edit the content of `soup.md` {.unnumbered}
+## Rename and move the soup recipe to a new folder
 
-When we added the content of the file, you might have noticed that it
-said "Ingredients for soup" on the first line. This is a bit generic, so
-let's change it.
+Moving and renaming files are other common tasks. Let's imagine that we
+want to add more recipes to the repository in the future. To keep things
+organised, we want our recipes to have descriptive names. We also want
+to create some folders to group similar recipes together.
 
-Like before, we'll click the `soup.md` file in the "Code" tab of the
-repository to open it and click the pencil icon {{< var pencil-icon >}}
-on the top-right side of the page.
-
-Now, let's revise the first line of the file to be "Ingredients for
-tomato soup". Once we've made the changes, let's commit them.
-{{< var github-commit >}}
-
-::: callout-tip
-A descriptive commit message for these changes could be "Add 'tomato' to
-the heading of the soup recipe".
-:::
-
-### Rename `soup.md` {.unnumbered}
+### Rename `soup.md` to `tomato-soup.md` {.unnumbered}
 
 Let's start by renaming the `soup.md` file. We'll go to the `soup.md`
-file in the repository by clicking on it in the "Code" tab. Then, we'll
+file in the repository by clicking on it in the "Code" tab. To rename
+files or move them, we have to "edit" them like we did above. So we'll
 click the pencil icon {{< var pencil-icon >}} on the top-right side of
 the page to edit the file.
 
@@ -212,20 +171,15 @@ click on the name and rename the file to `tomato-soup.md`. Remember to
 keep the `.md` file extension.
 
 Once we have renamed the file, let's commit the changes.
-{{< var github-commit >}}
-
-::: callout-tip
-A descriptive commit message for these changes could be "Rename soup.md
-to tomato-soup.md".
-:::
+{{< var github-commit-start >}} Write the commit message for these
+changes as "Rename soup.md to tomato-soup.md".
+{{< var github-commit-end >}}
 
 ### Move `tomato-soup.md` to a new `soups/` folder {.unnumbered}
 
-Next, let's move the `tomato-soup.md` file to a new `soups/` folder.
-
-As before, we'll click the `tomato-soup.md` file to open it and click
-the pencil icon {{< var pencil-icon >}} on the top-right side of the
-page.
+Next, let's move the `tomato-soup.md` file to a new `soups/` folder. As
+before, we'll click the `tomato-soup.md` file to open it and click the
+pencil icon {{< var pencil-icon >}} on the top-right side of the page.
 
 Now, let's change the path of the file to a new folder in the
 repository, by adding `soups/` before the file name like so:
@@ -233,44 +187,36 @@ repository, by adding `soups/` before the file name like so:
 the file name.
 
 This will create a new folder in your `recipes` repository called
-`soups/` and then move the `tomato-soup.md` file into it.
+`soups/` and then move the `tomato-soup.md` file into it. Noticed that
+once we add the slash `/` after the folder name, GitHub moves the cursor
+to the end of the file path, to the file name. This might make it seem
+like we can't go back to the folder name and correct it if we make a
+typo or want to change it.
 
-::: callout-tip
-### Fixing a folder name after typing slash `/`
-
-You might have noticed that once we add the slash `/` after the folder
-name, GitHub moves the cursor to the end of the file path, to the file
-name. This might make it seem like we can't go back to the folder name
-and correct it if we make a typo or want to change it.
-
-However, we can use the backspace key to remove the `/` which leads the
+But we can still change it! If we make a mistake in the folder name, we
+can fix it by using the backspace key to remove the `/`, moving the
 cursor back to the folder name. Now, we can change the folder name as we
 like :partying_face:
-:::
 
-{{< var github-commit >}}
+{{< var github-commit-start >}} Write a message for these changes to be
+"Move tomato soup recipe into a new soups folder".
+{{< var github-commit-end >}}
+
+We've moved it! You can see the new folder `soups/` in the `Code` tab of
+your repository and even click on it to see the `tomato-soup.md` file.
+:bowl_with_spoon: :tomato:
 
 ::: callout-tip
-A descriptive message for these changes could be "Move tomato soup
-recipe into a new soups folder".
-:::
-
-We have now renamed the soup recipe file, edited its content, and moved
-it to a new folder in your repository! You can see the new folder
-`soups/` in the `Code` tab of your repository and even click on it to
-see the `tomato-soup.md` file. :bowl_with_spoon: :tomato:
-
-::: callout-note
-### Editing, renaming and moving files can be done in the same step
+### Editing, renaming and moving files at the same time
 
 It is possible to edit, rename, and move files in the same step if you
-want to. However, for practice and clarity in the history, we've split
-these changes into separate steps.
+want to. For this workshop, we've split these changes into separate
+steps to highlight how to do each.
 :::
 
 ## :technologist: Exercise: edit, rename, and move the `cookies.md` file
 
-**Time: \~10 minutes**
+**Time: \~5 minutes**
 
 Just like we did with the soup recipe above, let's rename the
 `cookies.md` file so the name is more specific. Let's also move it to a


### PR DESCRIPTION
# Description

This removes the sections on "copying" the recipes, instead writing them out. They are also shorter now. Also simplifies and shortens other sentences and paragraphs related to this change.

Closes #196

## Checklist

- [x] Formatted Markdown
- [x] Ran `just run-all`
