### PR TITLE
refactor(sessions)!: :truck: move file deletion section into FAQ

### DIFF
--- a/appendix/faq.qmd
+++ b/appendix/faq.qmd
@@ -1,0 +1,40 @@
+# FAQ
+
+## How can I delete files in a GitHub repository?
+
+Working with the files we created during the sessions, let's say you
+want to use our repository for recipes of only sweets, desserts, and
+baked goods. This means that you will need to remove the tomato soup
+recipe from the repository.
+
+To delete the `tomato-soup.md` file, you'd click the `soups/` folder in
+the "Code" tab of the repository and then click the `tomato-soup.md`
+file within it.
+
+In the top-right corner of the page, you'd click the button with three
+dots ({{< var ellipsis-icon >}}), scroll down to the bottom of the
+dropdown menu and click "Delete file".
+
+You'd save the changes (the deletion) by committing the changes as
+you've done during the workshop.
+
+When looking at the files and folders in the repository now, you might
+notice something unexpected: When we deleted the `tomato-soup.md` file,
+GitHub automatically deleted the `soups/` folder as well! This is
+because the folder only contained that one file. GitHub will
+automatically remove empty folders if there is only only file was it and
+it was deleted. So, we don't need to delete the `soups/` folder
+separately. :fire:
+
+You've now deleted the tomato soup recipe and the `soups/` folder from
+the repository and are ready to focus on sweets and baked goods! :cake:
+
+## How can I delete a folder with multiple files?
+
+If you wanted to delete a folder with multiple files in it along with
+the files themselves, you can go to the folder and click the three dots
+button ({{< var ellipsis-icon >}}) in the top-right corner of the page.
+Then, click "Delete directory" in the dropdown menu.
+
+This will delete the folder and all the files within it, so be careful
+with deleting folders directly like this.

--- a/includes/objectives/_working-with-files.qmd
+++ b/includes/objectives/_working-with-files.qmd
@@ -1,4 +1,4 @@
--   Navigate GitHub to create, upload, rename, edit, and delete files
+-   Navigate GitHub to create, upload, rename, and edit files
     and folders.
 -   Use good naming practices for files and folders.
 -   Use the GitHub history page to explore and find previous changes

--- a/sessions/conclusion.qmd
+++ b/sessions/conclusion.qmd
@@ -10,7 +10,7 @@ More specifically, we've:
 
 -   Created a repository on GitHub
 -   Worked with files in our own repository on GitHub: Created, edited,
-    renamed, and deleted recipe files and folders
+    and renamed recipe files and folders
 -   Created and commented on GitHub issues
 
 Let's spend a few minutes thinking about how you might use GitHub in

--- a/sessions/introduction.qmd
+++ b/sessions/introduction.qmd
@@ -26,15 +26,16 @@ to expect. We've already covered a lot of these things in detail in
 brief reminder.
 
 -   We do **"type-alongs" or "code-alongs"** where the teacher types and
-    shows how to do things and explains what they are doing
-    and why, while you type along.
+    shows how to do things and explains what they are doing and why,
+    while you type along.
 
--   **Reading tasks** are used to give you time to think and
-    process at your own pace. After the reading task, the teacher repeats and
+-   **Reading tasks** are used to give you time to think and process at
+    your own pace. After the reading task, the teacher repeats and
     rephrases the key points to reinforce the concepts you just read.
 
--   **Discussion activities** are used to reflect on the workshop content and give
-    you a chance to talk to your peers about the concepts.
+-   **Discussion activities** are used to reflect on the workshop
+    content and give you a chance to talk to your peers about the
+    concepts.
 
 -   We use **"stickies", origami hats, or other visual indicators** to
     assess how everyone is doing and for you to request help if you get
@@ -42,8 +43,8 @@ brief reminder.
     will come by as soon as they are available and help you out.
 
 -   The [**schedule**](/overview/schedule.qmd) **is a *guide* only**,
-    some sessions might be longer, others shorter. It is not intended to be
-    firm or strict.
+    some sessions might be longer, others shorter. It is not intended to
+    be firm or strict.
 
 -   We depend on and want **honest, constructive, and critical
     feedback** to improve the workshops. At the end of the workshop, you
@@ -90,10 +91,10 @@ learn the basics of Git and GitHub.
 
 3.  Then, in the third session, [Working with files on
     GitHub](/sessions/working-with-files.qmd), we will learn how to work
-    with files in Git and GitHub, including how to add, edit, and delete
-    files and folders.
+    with files in Git and GitHub, including how to add, and edit files
+    and folders.
 
 4.  Finally, in the last session on [GitHub
-    Issues](/sessions/using-issues.qmd), we will use GitHub
-    Issues to track tasks and discussions, and how to assign and tag
-    people in issues.
+    Issues](/sessions/using-issues.qmd), we will use GitHub Issues to
+    track tasks and discussions, and how to assign and tag people in
+    issues.

--- a/sessions/working-with-files.qmd
+++ b/sessions/working-with-files.qmd
@@ -319,45 +319,6 @@ folder in your repository! :partying_face:
 
 {{< text_snippet sticky_up >}}
 
-## Delete files and folders in a GitHub repository
-
-Let's imagine that we have decided that our recipe book should solely
-focus on recipes for sweets, desserts, and baked goods. This means that
-we want to remove the tomato soup recipe from the repository along with
-the `soups/`folder.
-
-To delete the `tomato-soup.md` file and the `soups/` folder, we'll click
-the `soups/` folder in the "Code" tab of the repository and then click
-the `tomato-soup.md` file within it.
-
-In the top-right corner of the page, we'll click the button with three
-dots ({{< var ellipsis-icon >}}), scroll down to the bottom of the
-dropdown menu and click "Delete file".
-
-We'll save the changes by committing the changes as we have done before.
-
-Now, when looking at the files and folders in the repository, you might
-notice something unexpected: When we deleted the `tomato-soup.md` file,
-GitHub automatically deleted the `soups/` folder as well! This is
-because the folder only contained that file. GitHub automatically
-removes empty folders when the last file in the folder is deleted. So,
-we don't need to delete the `soups/` folder separately. :fire:
-
-We have now deleted the tomato soup recipe and the `soups/` folder from
-the repository and are ready to focus on sweets and baked goods! :cake:
-
-::: callout-tip
-### Delete a folder with multiple files
-
-If you wanted to delete a folder with multiple files in it along with
-the files themselves, you can go to the folder and click the three dots
-button ({{< var ellipsis-icon >}}) in the top-right corner of the page.
-Then, click "Delete directory" in the dropdown menu.
-
-This will delete the folder and all the files within it, so be careful
-with deleting folders directly like this.
-:::
-
 ## Upload files to a GitHub repository
 
 ::: {.callout-note collapse="true"}
@@ -501,7 +462,6 @@ particular, we have:
 
 -   Added files and folders to a GitHub repository
 -   Renamed, edited, and moved files in the repository
--   Deleted files and folders from the repository
 -   Uploaded a local file to the repository
 -   Explored the history of the repository to see the changes and locate
     specific changes


### PR DESCRIPTION
BREAKING CHANGE: Deleting files is no longer part of the workshop, now only in FAQ.

# Description

This moves out the deleting files section into the FAQ.

## Checklist

- [x] Formatted Markdown
- [x] Ran `just run-all`
