### PR TITLE
fix: :pencil2: casing "Github" -> "GitHub

### DIFF
--- a/sessions/using-issues.qmd
+++ b/sessions/using-issues.qmd
@@ -246,6 +246,6 @@ have:
     the a chocolate mousse recipe in a new `sweets/` folder) and one to
     start brainstorming ideas on which recipes to add in the future.
 -   Explored GitHub notifications.
--   Navigated Github to find other people's repositories and issues.
+-   Navigated GitHub to find other people's repositories and issues.
 -   Started to collaborate a bit by commenting on someone else's issue
     to suggest a recipe.


### PR DESCRIPTION
# Description

Fixes casing of GitHub in the Issues session.